### PR TITLE
Fix large amount of options

### DIFF
--- a/blockly/core/field_dropdown.js
+++ b/blockly/core/field_dropdown.js
@@ -172,9 +172,14 @@ Blockly.FieldDropdown.prototype.showEditor_ = function() {
   menu.render(div);
   var menuDom = menu.getElement();
   Blockly.addClass_(menuDom, 'blocklyDropdownMenu');
+  
+  // Limit height (TODO: Update Blockly to newer version in order to avoid this workaround)
+  menuDom.style.maxHeight = '65vh';
+  menuDom.style.overflowY = 'auto';
+  
   // Record menuSize after adding menu.
   var menuSize = goog.style.getSize(menuDom);
-
+  
   // Position the menu.
   // Flip menu vertically if off the bottom.
   if (xy.y + menuSize.height + borderBBox.height >=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "BlocklyVN8bit",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Uses blockly to generate visual novels for 8bit-Unity",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
In order to correct a bug where the dropdown would exceed the height of the screen if there were too many images to show, its maximum height has been limited.